### PR TITLE
fix: Add attribute nonnull_error if returning pointer and error from Objective-C

### DIFF
--- a/bind/genobjc.go
+++ b/bind/genobjc.go
@@ -582,6 +582,11 @@ func (s *funcSummary) asSignature(g *ObjcGen) string {
 		}
 		params = append(params, fmt.Sprintf("%s:(%s)%s", key, g.objcType(p.typ)+"* _Nullable", p.name))
 	}
+	if params[len(params)-1] == ":(NSError* _Nullable* _Nullable)error" &&
+		(s.ret == "NSData* _Nullable" || s.ret == "NSString* _Nullable") {
+		// Allow returning nil to Swift.
+		params = append(params, "__attribute__((swift_error(nonnull_error)))")
+	}
 	return strings.Join(params, " ")
 }
 


### PR DESCRIPTION
Consider the following Go code with a method that returns a byte array and an error:

    package example

    type TestClass struct {
    }
    func (req *TestClass) GetData() ([]byte, error) {
            return nil, nil
    }

gobind creates an Objective-C method which returns `NSData*` and an error:

    - (NSData* _Nullable)getData:(NSError* _Nullable* _Nullable)error {
        ....
    }

The method signature seen by Swift is `func getData() throws -> Data` . The problem is that `Data` is not optional, and when the Objective-C method returns NULL the program crashes. This is the default signature as explained in the Swift documentation: https://clang.llvm.org/docs/AttributeReference.html#swift-error

But this is not appropriate for gobind since it is valid for Go to return a nil value. We don't want the crash. This pull request updates `asSignature` so that if the method returns an error and the method returns a nullable pointer to `NSData` or `NSString`, then add the `nonnull_error` attribute as explained in the Swift documentation.

With this attribute, the method signature seen by Swift is `func getData() throws -> Data?` . When the Go function returns nil, it is returned as a nil optional value without crashing.